### PR TITLE
Resolve strong reference issue

### DIFF
--- a/YMChat/YMChat.swift
+++ b/YMChat/YMChat.swift
@@ -13,7 +13,7 @@ public class YMChat: NSObject, YMChatViewControllerDelegate {
 
     @objc public var enableLogging = false
 
-    @objc public var viewController: YMChatViewController?
+    @objc weak public var viewController: YMChatViewController?
     @objc public var config: YMConfig!
 
     func validateConfig() throws {
@@ -54,14 +54,15 @@ public class YMChat: NSObject, YMChatViewControllerDelegate {
     @discardableResult
     @objc public func initialiseView() throws -> YMChatViewController {
         try validateConfig()
-        self.viewController = YMChatViewController(config: config)
-        self.viewController?.delegate = self
-        return viewController!
+        let viewController = YMChatViewController(config: config)
+        viewController.delegate = self
+        self.viewController = viewController
+        return viewController
     }
 
     @objc public func startChatbot(on viewController: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil) throws {
-        try initialiseView()
-        viewController.present(self.viewController!, animated: animated, completion: completion)
+        let ymChatViewController = try initialiseView()
+        viewController.present(ymChatViewController, animated: animated, completion: completion)
     }
 
     @objc public func startChatbot(animated: Bool = true, completion: (() -> Void)? = nil) throws {


### PR DESCRIPTION
Because of the strong reference on the self.viewController, we have a memory issue. “deinit” method doesn’t work as expected. In my case, after we close the bot it is still alive in memory and it still reads messages from agents. When I execute the “getUnreadMessagesCount” method it returns 0 for some time, even though the bot was closed when the messages were sent. To fix this we need to stop web view, you’ve already done this in the “deinit” method, but it executes only when you present the bot again.