### PR TITLE
update/theme-setup

### DIFF
--- a/YMChat/YMTheme.swift
+++ b/YMChat/YMTheme.swift
@@ -12,6 +12,7 @@ public class YMTheme: NSObject, Encodable {
     @objc public var botName: String?
     @objc public var primaryColor: UIColor?
     @objc public var secondaryColor: UIColor?
+    @objc public var botBubbleBackgroundColor: UIColor?
     @objc public var botIcon: String?
     @objc public var botDescription: String?
     @objc public var botClickIcon: String?
@@ -20,6 +21,7 @@ public class YMTheme: NSObject, Encodable {
         case botName
         case primaryColor
         case secondaryColor
+        case botBubbleBackgroundColor
         case botIcon
         case botDesc
         case botClickIcon
@@ -30,6 +32,7 @@ public class YMTheme: NSObject, Encodable {
         try container.encodeIfPresent(self.botName, forKey: .botName)
         try container.encodeIfPresent(self.primaryColor?.hex, forKey: .primaryColor)
         try container.encodeIfPresent(self.secondaryColor?.hex, forKey: .secondaryColor)
+        try container.encodeIfPresent(self.botBubbleBackgroundColor?.hex, forKey: .botBubbleBackgroundColor)
         try container.encodeIfPresent(self.botIcon, forKey: .botIcon)
         try container.encodeIfPresent(self.botDescription, forKey: .botDesc)
         try container.encodeIfPresent(self.botClickIcon, forKey: .botClickIcon)


### PR DESCRIPTION
- added botBubbleBackgroundColor in YMTheme model to make change for background color for bot bubble
```swift 
        let theme = YMTheme()
        theme.botName = "Demo Bot Name"
        theme.botDescription = "Demo Bot Description"
        theme.primaryColor = .red
        theme.secondaryColor = .blue
        theme.botBubbleBackgroundColor = .green
        theme.botIcon = "https://cdn.yellowmessenger.com/XJFcMhLpN6L91684914460598.png"
        config.theme = theme
```
<img width="400" alt="Screenshot 2024-05-14 at 11 18 00 AM" src="https://github.com/yellowmessenger/YMChatbot-iOS/assets/123462379/af788610-fbcc-4a34-ae7f-920ef29832e5">

