### PR TITLE
feature/chatBotTheme

### DIFF
--- a/YMChat/YMTheme.swift
+++ b/YMChat/YMTheme.swift
@@ -16,6 +16,7 @@ public class YMTheme: NSObject, Encodable {
     @objc public var botIcon: String?
     @objc public var botDescription: String?
     @objc public var botClickIcon: String?
+    @objc public var chatBotTheme: String?
     
     enum CodingKeys: CodingKey {
         case botName
@@ -25,6 +26,7 @@ public class YMTheme: NSObject, Encodable {
         case botIcon
         case botDesc
         case botClickIcon
+        case chatBotTheme
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -36,5 +38,6 @@ public class YMTheme: NSObject, Encodable {
         try container.encodeIfPresent(self.botIcon, forKey: .botIcon)
         try container.encodeIfPresent(self.botDescription, forKey: .botDesc)
         try container.encodeIfPresent(self.botClickIcon, forKey: .botClickIcon)
+        try container.encodeIfPresent(self.chatBotTheme, forKey: .chatBotTheme)
     }
 }


### PR DESCRIPTION
-  To add custom background color for chat conatiner, 
    - set `chatBotTheme = "light"` or  `chatBotTheme = "dark"` in `YMTheme`
```swift      
let theme = YMTheme()
theme.chatBotTheme = "light"
config.theme = theme
``` 
 -  make sure these properties are added in skin of bot mapping api `chatBotLightThemeBackgroundColor` and `chatBotDarkThemeBackgroundColor` 
```javascript
"skin": {
   ...
   "chatBotLightThemeBackgroundColor": "#F6EACB",
   "chatBotDarkThemeBackgroundColor": "#FF8A8A"
}
```