### PR TITLE
Enforce http(s)-only scheme allowlist on all WebView navigations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 -----
 
+## [v2.2.1](https://github.com/yellowmessenger/YMChatbot-iOS/releases/tag/2.2.1) (2026-07-23)
+
+#### Security 🔒
+* Enforced an `http`/`https`-only scheme allowlist in the WebView's navigation policy, covering all navigation types (not just tapped links). Blocks `javascript:`, `file:`, and other non-http(s) URLs from loading directly in the WebView.
+
+---
+
 ## [v2.2.0](https://github.com/yellowmessenger/YMChatbot-iOS/releases/tag/2.2.0) (2026-05-08)
 
 #### New Update 🚀

--- a/YMChat.podspec
+++ b/YMChat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "YMChat"
-  spec.version = "2.2.0"
+  spec.version = "2.2.1"
 
   spec.summary = "The World’s Leading CX Automation Platform"
   spec.homepage = "https://yellow.ai"

--- a/YMChat/Info.plist
+++ b/YMChat/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/YMChat/YMChatViewController.swift
+++ b/YMChat/YMChatViewController.swift
@@ -389,27 +389,56 @@ extension YMChatViewController: WKNavigationDelegate, WKScriptMessageHandler {
     }
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        guard navigationAction.navigationType == .linkActivated,
-              let url = navigationAction.request.url,
-              UIApplication.shared.canOpenURL(url) else {
+        guard let url = navigationAction.request.url else {
             decisionHandler(.allow)
             return
         }
-        
+
+        let scheme = url.scheme?.lowercased()
+        let isWebScheme = scheme == "http" || scheme == "https"
+
+        if !isWebScheme && !isTrustedLocalAsset(url) {
+            // javascript:, file:, data: and any other non-http(s) navigation must never be
+            // allowed to load inside the WebView itself, whether it comes from a tapped link,
+            // a script-driven navigation, or a redirect.
+            if navigationAction.navigationType == .linkActivated {
+                if config.shouldOpenLinkExternally {
+                    if UIApplication.shared.canOpenURL(url) {
+                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    }
+                } else {
+                    forwardUrlClicked(url)
+                }
+            }
+            decisionHandler(.cancel)
+            return
+        }
+
+        guard navigationAction.navigationType == .linkActivated else {
+            decisionHandler(.allow)
+            return
+        }
+
         if config.shouldOpenLinkExternally {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
-            decisionHandler(.cancel)
         } else {
-            let urlPayload = ["url": url.absoluteString]
-            guard let urlData = try? JSONSerialization.data(withJSONObject: urlPayload),
-                  let urlString = String(data: urlData, encoding: .utf8) else {
-                decisionHandler(.cancel)
-                return
-            }
-            
-            delegate?.eventReceivedFromBot(code: "url-clicked", data: urlString)
-            decisionHandler(.cancel)
+            forwardUrlClicked(url)
         }
+        decisionHandler(.cancel)
+    }
+
+    private func isTrustedLocalAsset(_ url: URL) -> Bool {
+        guard url.isFileURL else { return false }
+        return url.path.hasPrefix(Bundle.assetBundle.bundlePath)
+    }
+
+    private func forwardUrlClicked(_ url: URL) {
+        let urlPayload = ["url": url.absoluteString]
+        guard let urlData = try? JSONSerialization.data(withJSONObject: urlPayload),
+              let urlString = String(data: urlData, encoding: .utf8) else {
+            return
+        }
+        delegate?.eventReceivedFromBot(code: "url-clicked", data: urlString)
     }
 }
 

--- a/YMChatTests/Info.plist
+++ b/YMChatTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## Summary
- `decidePolicyFor navigationAction` only applied the `shouldOpenLinkExternally` / `url-clicked` logic to `.linkActivated` navigations, and even then fell through to `.allow` whenever `UIApplication.canOpenURL(url)` returned `false` — which it reliably does for `javascript:` and often `file:` URLs. That let a tapped `javascript:`/`file:` link, or a non-tap navigation (JS `window.location`, form submit, redirect), load directly in the WebView instead of being blocked or handed off externally.
- Now enforces an `http`/`https`-only allowlist across **all** navigation types (not just tapped links), with the app's own bundled HTML load exempted so the initial load and reloads are unaffected.
- Bumps version to `2.2.1` (podspec + both `Info.plist`s) and adds a changelog entry (patch release — bug/security fix only, no API changes).

## Why
Companion fix to the same class of issue found and fixed in `YMChatbot-Android` (tracked as ISS-15626, from a validated bug bounty report). The Android SDK exposed a JS bridge method that loaded arbitrary URLs with no scheme check, and its main-frame navigation policy loaded links in-WebView instead of externally despite `shouldOpenLinkExternally = true`. iOS doesn't have a direct equivalent of that JS bridge or of `allowFileAccess`, but auditing the analogous WebView navigation-policy code here turned up this narrower gap in the same category (unrestricted scheme reaching the WebView loader).

## Test plan
- [x] `xcodebuild -scheme YMChat -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build` — BUILD SUCCEEDED.
- [ ] Manual check: tapping an `http(s)` link in chat still opens the system browser (or forwards `url-clicked`, per config) as before.
- [ ] Manual check: initial chatbot load and `reload()` still work (local bundled HTML load path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)