### PR TITLE
Keep screen awake during Voice Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 -----
 
+## [v2.3.0](https://github.com/yellowmessenger/YMChatbot-iOS/releases/tag/2.3.0) (2026-08-06)
+
+#### New Update 🚀
+* Added automatic screen-awake handling during Voice Mode: the SDK now disables the idle timer for the duration of an active voice conversation (driven by `voice-mode-started`/`voice-mode-ended` events from the web widget) and restores normal screen-timeout behavior as soon as the call ends.
+
+---
+
 ## [v2.2.1](https://github.com/yellowmessenger/YMChatbot-iOS/releases/tag/2.2.1) (2026-07-23)
 
 #### Security 🔒

--- a/YMChat.podspec
+++ b/YMChat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "YMChat"
-  spec.version = "2.2.1"
+  spec.version = "2.3.0"
 
   spec.summary = "The World’s Leading CX Automation Platform"
   spec.homepage = "https://yellow.ai"

--- a/YMChat/Info.plist
+++ b/YMChat/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/YMChat/YMChatViewController.swift
+++ b/YMChat/YMChatViewController.swift
@@ -36,6 +36,8 @@ open class YMChatViewController: UIViewController {
     private var micRightConstraint: NSLayoutConstraint?
     private let statusBarView = UIView()
 
+    private var isVoiceIdleTimerLockActive = false
+
     init(config: YMConfig) {
         self.config = config
         self.micButton = MicButton(config.speechConfig)
@@ -53,6 +55,22 @@ open class YMChatViewController: UIViewController {
 
     deinit {
         webView?.stopLoading()
+        releaseVoiceIdleTimerLock()
+    }
+
+    /// Keeps the screen awake while Voice Mode is active, driven by "voice-mode-started"/
+    /// "voice-mode-ended" events from the web widget. `isIdleTimerDisabled` is a global,
+    /// app-wide flag, so we track our own state and only ever toggle it from our own transitions.
+    private func acquireVoiceIdleTimerLock() {
+        guard !isVoiceIdleTimerLockActive else { return }
+        UIApplication.shared.isIdleTimerDisabled = true
+        isVoiceIdleTimerLockActive = true
+    }
+
+    private func releaseVoiceIdleTimerLock() {
+        guard isVoiceIdleTimerLockActive else { return }
+        UIApplication.shared.isIdleTimerDisabled = false
+        isVoiceIdleTimerLockActive = false
     }
     
     private func setupStatusBarView() {
@@ -95,6 +113,7 @@ open class YMChatViewController: UIViewController {
         NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
         self.stopVoiceMode()
+        releaseVoiceIdleTimerLock()
     }
     
     @objc func applicationDidEnterInBackground(notification: Notification) {
@@ -337,6 +356,10 @@ extension YMChatViewController: SpeechDelegate {
             if let data = data, config.statusBarColor == .white {
                 statusBarView.backgroundColor = UIColor(data)
             }
+        case "voice-mode-started":
+            acquireVoiceIdleTimerLock()
+        case "voice-mode-ended":
+            releaseVoiceIdleTimerLock()
         default: break
         }
     }

--- a/YMChatTests/Info.plist
+++ b/YMChatTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## Summary
- Adds `acquireVoiceIdleTimerLock()`/`releaseVoiceIdleTimerLock()` toggling `UIApplication.shared.isIdleTimerDisabled`.
- Driven by new `voice-mode-started`/`voice-mode-ended` bridge events from the web widget (companion PR in web-app), with safety-net release in `viewWillDisappear` and `deinit`.

## Test plan
- [x] `swiftc -typecheck` — clean (pre-existing warnings only)
- [ ] Manual: start Voice Mode in a voice-enabled bot, confirm idle timer stays disabled during the call, and restores on call end and on view controller teardown mid-call